### PR TITLE
Mac OS X: fixed deprecation and added maven configuration for native build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.DS_Store
+xcuserdata

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .DS_Store
 xcuserdata
+/*.jnilib

--- a/pom.xml
+++ b/pom.xml
@@ -224,12 +224,68 @@ along with jpen.  If not, see <http://www.gnu.org/licenses/>.
       <id>osx</id>
       <activation>
         <os>
-          <name>mac os x</name>
+          <name>mac os x</name>          
         </os>
+        <file>
+            <exists>/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers/</exists>
+        </file>    
       </activation>
       <properties>
         <source.dir>src/main/c/osx</source.dir>
       </properties>
+      <build>
+          <plugins>
+              <plugin>
+                  <groupId>com.github.maven-nar</groupId>
+                  <artifactId>nar-maven-plugin</artifactId>
+                  <configuration>
+                      <output>jpen-${module.version}-${jpen.provider.osx.nativeVersion}</output>
+                      <c>
+                          <name>gcc</name>
+                          <options>
+                              <option>-mmacosx-version-min=10.7</option>
+                              <option>-arch</option>
+                              <option>x86_64</option>     
+                              <option>-arch</option>
+                              <option>i386</option>                             
+                          </options>
+                      </c>
+                      <linker>
+                          <options>
+                              <option>-mmacosx-version-min=10.7</option>
+                              <option>-arch</option>
+                              <option>x86_64</option>
+                              <option>-arch</option>
+                              <option>i386</option>
+                              <option>-framework</option>
+                              <option>Cocoa</option>
+                              <option>-framework</option>
+                              <option>Carbon</option>
+                              <option>-framework</option>
+                              <option>JavaVM</option>
+                          </options>
+                      </linker>
+                  </configuration>
+              </plugin>
+              <!-- Workaround for nar-integration-test not setting java.library.path on macOS 10.12 -->
+              <plugin>
+                  <artifactId>maven-antrun-plugin</artifactId>
+                  <executions>
+                      <execution>
+                          <phase>pre-integration-test</phase>
+                          <configuration>
+                              <tasks>
+                                 <copy file="${project.basedir}/target/nar/${module.id-fullVer}-x86_64-MacOSX-gpp-jni/lib/x86_64-MacOSX-gpp/jni/libjpen-${module.version}-${jpen.provider.osx.nativeVersion}.jnilib" todir="${project.basedir}"/>
+                              </tasks>
+                          </configuration>
+                          <goals>
+                              <goal>run</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+              </plugin>
+          </plugins>
+      </build>
     </profile>
     <profile>
       <id>win</id>

--- a/src/main/c/osx/JPen-JNI-MacOSX.xcodeproj/project.pbxproj
+++ b/src/main/c/osx/JPen-JNI-MacOSX.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 42;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -67,7 +67,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		AD2E423010EB21260036410B /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
+		AD2E423010EB21260036410B /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = /System/Library/Frameworks/Carbon.framework; sourceTree = "<absolute>"; };
 		ADDE1A4C11324FA100226E22 /* osx-BuildNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "osx-BuildNumber.h"; path = "../nativeBuild/osx-BuildNumber.h"; sourceTree = SOURCE_ROOT; };
 		ADDE1A4E11324FAB00226E22 /* JRSwizzle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JRSwizzle.h; sourceTree = "<group>"; };
 		ADDE1A4F11324FAB00226E22 /* JRSwizzle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JRSwizzle.m; sourceTree = "<group>"; };
@@ -76,8 +76,8 @@
 		ADDE1A5211324FAB00226E22 /* osx_push_provider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = osx_push_provider.m; sourceTree = "<group>"; };
 		ADDE1A5311324FAB00226E22 /* WacomAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WacomAccess.h; sourceTree = "<group>"; };
 		ADDE1A5411324FAB00226E22 /* WacomAccess.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WacomAccess.m; sourceTree = "<group>"; };
-		ADDE1A5C11324FB100226E22 /* libjpen-2-3.jnilib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libjpen-2-3.jnilib"; sourceTree = BUILT_PRODUCTS_DIR; };
-		ADDE1A5D11324FB100226E22 /* libjpen-2-3-tiger.jnilib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libjpen-2-3-tiger.jnilib"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ADDE1A5C11324FB100226E22 /* libjpen-2.jnilib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libjpen-2.jnilib"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ADDE1A5D11324FB100226E22 /* libjpen-2.jnilib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libjpen-2.jnilib"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDC2546A0EC52A7A00984EE2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		FDC2546B0EC52A7A00984EE2 /* JavaVM.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaVM.framework; path = /System/Library/Frameworks/JavaVM.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
@@ -142,8 +142,8 @@
 		FDC252BF0EC51FEA00984EE2 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				ADDE1A5C11324FB100226E22 /* libjpen-2-3.jnilib */,
-				ADDE1A5D11324FB100226E22 /* libjpen-2-3-tiger.jnilib */,
+				ADDE1A5C11324FB100226E22 /* libjpen-2.jnilib */,
+				ADDE1A5D11324FB100226E22 /* libjpen-2.jnilib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -205,7 +205,7 @@
 			);
 			name = "jnilib-tiger";
 			productName = "jpen-2";
-			productReference = ADDE1A5D11324FB100226E22 /* libjpen-2-3-tiger.jnilib */;
+			productReference = ADDE1A5D11324FB100226E22 /* libjpen-2.jnilib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 		FDC2544A0EC5286700984EE2 /* jnilib */ = {
@@ -224,7 +224,7 @@
 			);
 			name = jnilib;
 			productName = "jpen-2";
-			productReference = ADDE1A5C11324FB100226E22 /* libjpen-2-3.jnilib */;
+			productReference = ADDE1A5C11324FB100226E22 /* libjpen-2.jnilib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */
@@ -232,9 +232,16 @@
 /* Begin PBXProject section */
 		FDC252A40EC51E7600984EE2 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0820;
+			};
 			buildConfigurationList = FDC252A70EC51E7600984EE2 /* Build configuration list for PBXProject "JPen-JNI-MacOSX" */;
-			compatibilityVersion = "Xcode 2.4";
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
 			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
 			mainGroup = FDC252A20EC51E7600984EE2;
 			productRefGroup = FDC252BF0EC51FEA00984EE2 /* Products */;
 			projectDirPath = "";
@@ -301,9 +308,8 @@
 		AD466FCE110C3DBC004B89F4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1)";
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
-				ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1 = "ppc i386";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -317,7 +323,7 @@
 				GCC_VERSION = 4.0;
 				HEADER_SEARCH_PATHS = "$(SDKROOT)/System/Library/Frameworks/JavaVM.framework/Headers";
 				INSTALL_PATH = /usr/local/lib;
-				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
@@ -326,7 +332,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "jpen-2-3-tiger";
-				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.4u.sdk";
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -334,23 +340,57 @@
 		FDC252A50EC51E7600984EE2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
-				VALID_ARCHS = "i386 ppc x86_64";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				SDKROOT = macosx10.12;
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
 		};
 		FDC252A60EC51E7600984EE2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
-				VALID_ARCHS = "i386 ppc x86_64";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				SDKROOT = macosx10.12;
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};
@@ -387,8 +427,7 @@
 		FDC2544D0EC5286700984EE2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "x86_64 i386 ppc";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -409,7 +448,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "jpen-2-3";
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				ZERO_LINK = NO;
 			};
 			name = Release;

--- a/src/main/c/osx/JPen-JNI-MacOSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/src/main/c/osx/JPen-JNI-MacOSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/src/main/c/osx/JPen-JNI-MacOSX.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/main/c/osx/JPen-JNI-MacOSX.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/src/test/java/jpen/test/SmokeTest.java
+++ b/src/test/java/jpen/test/SmokeTest.java
@@ -29,6 +29,7 @@ public class SmokeTest extends TestCase {
 	public void testPenManager() throws Exception {
 		JComponent component = new JPanel();
 		PenManager penManager = new PenManager(component);
+                System.out.println("java.library.path="+System.getProperty("java.library.path"));
 		System.out.println("Providers:");
 		int count=0;
 		for(PenProvider.Constructor constructor: penManager.getProviderConstructors()){


### PR DESCRIPTION
Hello,

this pull request fixes #2 (the build issue on mac os x 10.12).

The compiler error was fixed using a replacement for a deprecated attribute name
and the linker error was solved by setting nar-maven-plugin configuration in pom.xml

As I had to comment (or remove) the old workaround (which was to avoid accessing a nonexistent attribute) I tested it additionally with a Logitech M185 (normal scroll mouse) and there was 
no assertion error (see comment on the reason for the original workaround).

I added a workaround for the maven integration-test because of java.library.path
not being set by the nar-plugin on mac os (resulting in "build failure"). 
At first i tried setting it manually, but this seems only possible for surefire-tests 
not for the nar-integration-test. So i used the given path and configured an ant task 
to copy the binary to the projects base directory where it is found by the lib loader.

I also tried to fix the rotation issue for mac os, but until now this pull request does not
contain anything for that. I will write about that on the Rotation-Test issue.
