### PR TITLE
inverted the rotation direction in the wintab provider

### DIFF
--- a/src/main/java/jpen/provider/wintab/WintabDevice.java
+++ b/src/main/java/jpen/provider/wintab/WintabDevice.java
@@ -195,8 +195,10 @@ class WintabDevice
 									rangedValue*wintabProvider.screenBounds.getLevelRangeMult(type);
 		}
 
-		if(PLevel.Type.ROTATION.equals(type))
-			rangedValue*=PI_2;
+		if(PLevel.Type.ROTATION.equals(type)){			
+                        rangedValue= 1 - rangedValue; // invert direction to be the same as on linux and like written in the PLevel javadoc
+                        rangedValue*=PI_2;
+                }
 
 		return rangedValue;
 	}


### PR DESCRIPTION
Hello Nicolas,

As the rotation tests with the Art Pen (see #5 ) showed that the value increases on Linux and Windows in the opposite direction I thought it could be fixed by inverting one so that all providers are in the same direction. I selected to invert the windows provider (not knowing about the results on macOS) because it then behaves like written in the javadoc and existing code - written accordingly - does not have to be changed.
