### PR TITLE
Inverted rotation direction on macOS to increment clockwise

### DIFF
--- a/src/main/java/jpen/provider/osx/CocoaAccess.java
+++ b/src/main/java/jpen/provider/osx/CocoaAccess.java
@@ -321,7 +321,13 @@ final class CocoaAccess {
 				levels.add(new PLevel(PLevel.Type.PRESSURE, pressure));
 				levels.add(new PLevel(PLevel.Type.SIDE_PRESSURE, tangentialPressure));
 				// Cocoa tablet rotation is in degrees
-				levels.add(new PLevel(PLevel.Type.ROTATION, rotation*RADIANS_PER_DEGREE));
+                                 float invertedRotation ;
+                                 if (rotation == 0.0f) { 
+                                    invertedRotation = 0.0f ; 
+                                 } else {
+                                    invertedRotation = 360f - rotation;
+                                 }
+				levels.add(new PLevel(PLevel.Type.ROTATION, invertedRotation*RADIANS_PER_DEGREE));
 				cocoaProvider.getPenManager().scheduleLevelEvent(device, deviceTime, levels, true);
 			}
 		});


### PR DESCRIPTION
Hello,

this pull request inverts the rotation direction on macOS.
Recent Wacom drivers inverted the rotation direction to be the same as on windows (see #5)

The if statement leaves the rotation at 0 degrees for pens without rotation capabilities.

Since the rotation on linux increments clockwise and is coupled to the side-pressure value
I thought it's easier to invert it on macOS and Windows.

Greetings - and thank you,
Hannes Schäuble