### PR TITLE
leave inverted rotation at 0 instead of 360 degrees if stylus without rotation is used

### DIFF
--- a/src/main/java/jpen/provider/wintab/WintabDevice.java
+++ b/src/main/java/jpen/provider/wintab/WintabDevice.java
@@ -194,9 +194,12 @@ class WintabDevice
 									rangedValue*wintabProvider.screenBounds.getLevelRangeMult(type);
 		}
 
-		if(PLevel.Type.ROTATION.equals(type)){			
-                        rangedValue= 1 - rangedValue; // invert direction to be the same as on linux and like written in the PLevel javadoc
-                        rangedValue*=PI_2;
+		if(PLevel.Type.ROTATION.equals(type)){
+                    // invert direction to be the same as on linux and like written in the PLevel javadoc
+                    if ( rangedValue != 0.0f ) { // let rotation stay at 0 degrees for devices without rotation 
+                        rangedValue= 1 - rangedValue;
+                    }
+                    rangedValue*=PI_2;
                 }
 
 		return rangedValue;


### PR DESCRIPTION
Hello Nicolas,

this is a small bugfix targeting the inverted rotation in the wintab provider:
before the rotation resulted in 360 degrees if a stylus without rotation capabilities was used.

Kind regards,

Hannes Schäuble